### PR TITLE
Set schedule size according to oldest file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,10 @@ install: $(NAME)
 clean:
 	rm -f $(NAME) $(NAME).o
 
-test:
+
+test: test1 test2
+
+test1:
 	mkdir -p tfiles
 	for i in `seq 1 30` ; do touch -d "$$i days ago" tfiles/$$i ; done
 	expr `./fileprune -c 10 -n tfiles/* | wc -l` == 20
@@ -53,4 +56,14 @@ test:
 	! test -r tfiles/27
 	! test -r tfiles/28
 	! test -r tfiles/29
+	rm -rf tfiles
+
+test2:
+	mkdir -p tfiles
+	for i in 1 2 3 30 ; do touch -d "$$i days ago" tfiles/$$i ; done
+	./fileprune -e 2 tfiles/*
+	test -r tfiles/1
+	! test -r tfiles/2
+	test -r tfiles/3
+	test -r tfiles/30
 	rm -rf tfiles


### PR DESCRIPTION
by dynamically adjusting the size of the schedule until it is large
enough to encompass the oldest back (for exp, fib and simple counting).
This fixes #6.

For gauss I did not fully understand the code, so I did not change it.

Added a regression test to the “test suite” in the manpage.
